### PR TITLE
Feat cross app wf

### DIFF
--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -81,7 +81,6 @@ message ExecutionStartedEvent {
     TraceContext parentTraceContext = 7;
     google.protobuf.StringValue orchestrationSpanID = 8;
     map<string, string> tags = 9;
-    optional TaskRouter router = 10;
 }
 
 message ExecutionCompletedEvent {
@@ -100,19 +99,16 @@ message TaskScheduledEvent {
     google.protobuf.StringValue version = 2;
     google.protobuf.StringValue input = 3;
     TraceContext parentTraceContext = 4;
-    optional TaskRouter router = 5;
 }
 
 message TaskCompletedEvent {
     int32 taskScheduledId = 1;
     google.protobuf.StringValue result = 2;
-    optional TaskRouter router = 3;
 }
 
 message TaskFailedEvent {
     int32 taskScheduledId = 1;
     TaskFailureDetails failureDetails = 2;
-    optional TaskRouter router = 3;
 }
 
 message SubOrchestrationInstanceCreatedEvent {
@@ -121,31 +117,26 @@ message SubOrchestrationInstanceCreatedEvent {
     google.protobuf.StringValue version = 3;
     google.protobuf.StringValue input = 4;
     TraceContext parentTraceContext = 5;
-    optional TaskRouter router = 6;
 }
 
 message SubOrchestrationInstanceCompletedEvent {
     int32 taskScheduledId = 1;
     google.protobuf.StringValue result = 2;
-    optional TaskRouter router = 3;
 }
 
 message SubOrchestrationInstanceFailedEvent {
     int32 taskScheduledId = 1;
     TaskFailureDetails failureDetails = 2;
-    optional TaskRouter router = 3;
 }
 
 message TimerCreatedEvent {
     google.protobuf.Timestamp fireAt = 1;
     optional string name = 2;
-    optional TaskRouter router = 3;
 }
 
 message TimerFiredEvent {
     google.protobuf.Timestamp fireAt = 1;
     int32 timerId = 2;
-    optional TaskRouter router = 3;
 }
 
 message OrchestratorStartedEvent {
@@ -264,7 +255,7 @@ message HistoryEvent {
         EntityLockGrantedEvent entityLockGranted = 28;
         EntityUnlockSentEvent entityUnlockSent = 29;
     }
-    optional TaskRouter router = 30; // confirm if I need it here or in each individual events
+    optional TaskRouter router = 30;
 }
 
 message ScheduleTaskAction {
@@ -285,7 +276,6 @@ message CreateSubOrchestrationAction {
 message CreateTimerAction {
     google.protobuf.Timestamp fireAt = 1;
     optional string name = 2;
-    optional TaskRouter router = 3;
 }
 
 message SendEventAction {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -12,6 +12,11 @@ import "google/protobuf/duration.proto";
 import "google/protobuf/wrappers.proto";
 import "google/protobuf/empty.proto";
 
+message TaskRouter {
+    string source = 1; // orchestrationAppID
+    string target = 2; // appID
+}
+
 message OrchestrationInstance {
     string instanceId = 1;
     google.protobuf.StringValue executionId = 2;
@@ -76,6 +81,7 @@ message ExecutionStartedEvent {
     TraceContext parentTraceContext = 7;
     google.protobuf.StringValue orchestrationSpanID = 8;
     map<string, string> tags = 9;
+    optional TaskRouter router = 10;
 }
 
 message ExecutionCompletedEvent {
@@ -94,16 +100,19 @@ message TaskScheduledEvent {
     google.protobuf.StringValue version = 2;
     google.protobuf.StringValue input = 3;
     TraceContext parentTraceContext = 4;
+    optional TaskRouter router = 5;
 }
 
 message TaskCompletedEvent {
     int32 taskScheduledId = 1;
     google.protobuf.StringValue result = 2;
+    optional TaskRouter router = 3;
 }
 
 message TaskFailedEvent {
     int32 taskScheduledId = 1;
     TaskFailureDetails failureDetails = 2;
+    optional TaskRouter router = 3;
 }
 
 message SubOrchestrationInstanceCreatedEvent {
@@ -112,26 +121,31 @@ message SubOrchestrationInstanceCreatedEvent {
     google.protobuf.StringValue version = 3;
     google.protobuf.StringValue input = 4;
     TraceContext parentTraceContext = 5;
+    optional TaskRouter router = 6;
 }
 
 message SubOrchestrationInstanceCompletedEvent {
     int32 taskScheduledId = 1;
     google.protobuf.StringValue result = 2;
+    optional TaskRouter router = 3;
 }
 
 message SubOrchestrationInstanceFailedEvent {
     int32 taskScheduledId = 1;
     TaskFailureDetails failureDetails = 2;
+    optional TaskRouter router = 3;
 }
 
 message TimerCreatedEvent {
     google.protobuf.Timestamp fireAt = 1;
     optional string name = 2;
+    optional TaskRouter router = 3;
 }
 
 message TimerFiredEvent {
     google.protobuf.Timestamp fireAt = 1;
     int32 timerId = 2;
+    optional TaskRouter router = 3;
 }
 
 message OrchestratorStartedEvent {
@@ -192,10 +206,10 @@ message EntityOperationCalledEvent {
 }
 
 message EntityLockRequestedEvent {
-    string criticalSectionId = 1;  
+    string criticalSectionId = 1;
     repeated string lockSet = 2;
     int32 position = 3;
-    google.protobuf.StringValue parentInstanceId = 4; // used only within messages, null in histories 
+    google.protobuf.StringValue parentInstanceId = 4; // used only within messages, null in histories
 }
 
 message EntityOperationCompletedEvent {
@@ -210,14 +224,14 @@ message EntityOperationFailedEvent {
 
 message EntityUnlockSentEvent {
     string criticalSectionId = 1;
-    google.protobuf.StringValue parentInstanceId = 2;  // used only within messages, null in histories 
+    google.protobuf.StringValue parentInstanceId = 2;  // used only within messages, null in histories
     google.protobuf.StringValue targetInstanceId = 3;  // used only within histories, null in messages
 }
 
 message EntityLockGrantedEvent {
     string criticalSectionId = 1;
 }
- 
+
 message HistoryEvent {
     int32 eventId = 1;
     google.protobuf.Timestamp timestamp = 2;
@@ -244,18 +258,20 @@ message HistoryEvent {
         ExecutionResumedEvent executionResumed = 22;
         EntityOperationSignaledEvent entityOperationSignaled = 23;
         EntityOperationCalledEvent entityOperationCalled = 24;
-        EntityOperationCompletedEvent entityOperationCompleted = 25; 
-        EntityOperationFailedEvent entityOperationFailed = 26; 
+        EntityOperationCompletedEvent entityOperationCompleted = 25;
+        EntityOperationFailedEvent entityOperationFailed = 26;
         EntityLockRequestedEvent entityLockRequested = 27;
         EntityLockGrantedEvent entityLockGranted = 28;
         EntityUnlockSentEvent entityUnlockSent = 29;
     }
+    optional TaskRouter router = 30; // confirm if I need it here or in each individual events
 }
 
 message ScheduleTaskAction {
     string name = 1;
     google.protobuf.StringValue version = 2;
     google.protobuf.StringValue input = 3;
+    optional TaskRouter router = 4;
 }
 
 message CreateSubOrchestrationAction {
@@ -263,11 +279,13 @@ message CreateSubOrchestrationAction {
     string name = 2;
     google.protobuf.StringValue version = 3;
     google.protobuf.StringValue input = 4;
+    optional TaskRouter router = 5;
 }
 
 message CreateTimerAction {
     google.protobuf.Timestamp fireAt = 1;
     optional string name = 2;
+    optional TaskRouter router = 3;
 }
 
 message SendEventAction {
@@ -311,6 +329,7 @@ message OrchestratorAction {
         TerminateOrchestrationAction terminateOrchestration = 7;
         SendEntityMessageAction sendEntityMessage = 8;
     }
+    optional TaskRouter router = 9;
 }
 
 message OrchestratorRequest {
@@ -320,6 +339,7 @@ message OrchestratorRequest {
     repeated HistoryEvent newEvents = 4;
     OrchestratorEntityParameters entityParameters = 5;
     bool requiresHistoryStreaming = 6;
+    optional TaskRouter router = 7;
 }
 
 message OrchestratorResponse {


### PR DESCRIPTION
Add `taskrouter` with `source` and `target` as the orchestrator appid and target app id to enable cross application workflows, whereby one app may host the wf orchestrator and call an activity hosted by another app. Might need to add more or change the `suborchestrator` protos later on when I get to that. I'm starting with cross activity calls first, but do believe I'll need `CreateSubOrchestrationAction` to include the router so preemptively added it