### PR TITLE
chore: add codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# These owners are the maintainers and approvers of this repo
+*       @dapr/maintainers-dapr @dapr/approvers-dapr


### PR DESCRIPTION
This PR adds CODEOWNERS file since these durabletask protos are a natural extension of dapr runtime and should follow the same ownership.