### PR TITLE
Add missing fields to WorkflowMetadata

### DIFF
--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -98,8 +98,8 @@ message WorkflowMetadata {
   TaskFailureDetails failureDetails = 9;
   google.protobuf.Timestamp completedAt = 10;
   string parentInstanceId = 11;
-  google.protobuf.StringValue version = 12;
-  google.protobuf.StringValue parentAppId = 13;
+  optional google.protobuf.StringValue version = 12;
+  optional google.protobuf.StringValue parentAppId = 13;
 }
 
 message BackendWorkflowStateMetadata {

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -98,6 +98,7 @@ message WorkflowMetadata {
   TaskFailureDetails failureDetails = 9;
   google.protobuf.Timestamp completedAt = 10;
   string parentInstanceId = 11;
+  google.protobuf.StringValue version = 12;
 }
 
 message BackendWorkflowStateMetadata {

--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -99,6 +99,7 @@ message WorkflowMetadata {
   google.protobuf.Timestamp completedAt = 10;
   string parentInstanceId = 11;
   google.protobuf.StringValue version = 12;
+  google.protobuf.StringValue parentAppId = 13;
 }
 
 message BackendWorkflowStateMetadata {


### PR DESCRIPTION
Add version to `WorkflowMetadata`. The `version` field is defined as a string and not as an optional string because durable task library handles it in this way. 

Add paretent's appid for sub-workflows. This fields is optional.