### PR TITLE
Stalled: PAYLOAD_SIZE_EXCEEDED

### DIFF
--- a/protos/orchestration.proto
+++ b/protos/orchestration.proto
@@ -13,6 +13,7 @@ import "google/protobuf/wrappers.proto";
 enum StalledReason {
     PATCH_MISMATCH = 0;
     VERSION_NOT_AVAILABLE = 1;
+    PAYLOAD_SIZE_EXCEEDED = 2;
 }
 
 enum OrchestrationStatus {


### PR DESCRIPTION
Adds a new stalled reason for when the payload size of the workflow history or event exceeds the maximum size allowed by the transport layer.

Related: https://github.com/dapr/dapr/issues/9846