### PR TITLE
Adds messages to schedule detached workflows from workflows

### DIFF
--- a/protos/history_events.proto
+++ b/protos/history_events.proto
@@ -164,6 +164,16 @@ message ChildWorkflowInstanceFailedEvent {
     optional bytes signerCertificate = 4;
 }
 
+// NewWorkflowScheduledEvent records that a running workflow scheduled a new,
+// detached workflow instance via ScheduleNewWorkflowAction. The new workflow
+// has no parent linkage (no completion or failure flows back), so this event
+// only stores a pointer to the spawned instance — the inputs themselves are
+// consumed directly from the action when scheduling. Replay matches on
+// instanceId, so it is the same value the action carried.
+message NewWorkflowScheduledEvent {
+    string instanceId = 1;
+}
+
 // Indicates the timer was created by a createTimer call with no special origin.
 message TimerOriginCreateTimer {}
 
@@ -266,6 +276,7 @@ message HistoryEvent {
         ExecutionSuspendedEvent executionSuspended = 21;
         ExecutionResumedEvent executionResumed = 22;
         ExecutionStalledEvent executionStalled = 31;
+        NewWorkflowScheduledEvent newWorkflowScheduled = 32;
     }
     reserved 18, 19, 23, 24, 25, 26, 27, 28, 29;
     optional TaskRouter router = 30;

--- a/protos/history_events.proto
+++ b/protos/history_events.proto
@@ -164,13 +164,13 @@ message ChildWorkflowInstanceFailedEvent {
     optional bytes signerCertificate = 4;
 }
 
-// NewWorkflowScheduledEvent records that a running workflow scheduled a new,
-// detached workflow instance via ScheduleNewWorkflowAction. The new workflow
-// has no parent linkage (no completion or failure flows back), so this event
-// only stores a pointer to the spawned instance — the inputs themselves are
-// consumed directly from the action when scheduling. Replay matches on
-// instanceId, so it is the same value the action carried.
-message NewWorkflowScheduledEvent {
+// DetachedWorkflowInstanceCreatedEvent records that a running workflow
+// created a new, detached workflow instance via CreateDetachedWorkflowAction.
+// The new workflow has no parent linkage (no completion or failure flows
+// back), so this event only stores a pointer to the spawned instance — the
+// inputs themselves are consumed directly from the action when scheduling.
+// Replay matches on instanceId, so it is the same value the action carried.
+message DetachedWorkflowInstanceCreatedEvent {
     string instanceId = 1;
 }
 
@@ -276,7 +276,7 @@ message HistoryEvent {
         ExecutionSuspendedEvent executionSuspended = 21;
         ExecutionResumedEvent executionResumed = 22;
         ExecutionStalledEvent executionStalled = 31;
-        NewWorkflowScheduledEvent newWorkflowScheduled = 32;
+        DetachedWorkflowInstanceCreatedEvent detachedWorkflowInstanceCreated = 32;
     }
     reserved 18, 19, 23, 24, 25, 26, 27, 28, 29;
     optional TaskRouter router = 30;

--- a/protos/orchestrator_actions.proto
+++ b/protos/orchestrator_actions.proto
@@ -35,18 +35,19 @@ message CreateChildWorkflowAction {
     optional HistoryPropagationScope historyPropagationScope = 6;
 }
 
-// ScheduleNewWorkflowAction schedules a new, detached workflow instance from a
-// running workflow. Mirrors the fields of CreateInstanceRequest (the client
+// CreateDetachedWorkflowAction creates a new, detached workflow instance from
+// a running workflow. Mirrors the fields of CreateInstanceRequest (the client
 // scheduling API) so the runtime has all the information needed to schedule
 // the new instance directly from this action. The spawned workflow is fully
 // decoupled from the caller: no parent pointer is recorded on the new
 // workflow, no completion is awaited, and no failure propagation flows back.
-// The spawn is recorded once in the caller's history as a
-// NewWorkflowScheduledEvent referencing the new instance ID.
-message ScheduleNewWorkflowAction {
+// The creation is recorded once in the caller's history as a
+// DetachedWorkflowInstanceCreatedEvent referencing the new instance ID.
+message CreateDetachedWorkflowAction {
     // instanceId is the ID assigned to the new workflow. It is mandatory:
     // implementors must set a stable, deterministic ID so that on replay the
-    // call resolves to the same NewWorkflowScheduledEvent in history.
+    // call resolves to the same DetachedWorkflowInstanceCreatedEvent in
+    // history.
     string instanceId = 1;
     // name of the workflow to schedule. Mandatory.
     string name = 2;
@@ -110,7 +111,7 @@ message WorkflowAction {
         CompleteWorkflowAction completeWorkflow = 6;
         TerminateWorkflowAction terminateWorkflow = 7;
         WorkflowVersionNotAvailableAction workflowVersionNotAvailable = 10;
-        ScheduleNewWorkflowAction scheduleNewWorkflow = 11;
+        CreateDetachedWorkflowAction createDetachedWorkflow = 11;
     }
     reserved 8;
     optional TaskRouter router = 9;

--- a/protos/orchestrator_actions.proto
+++ b/protos/orchestrator_actions.proto
@@ -35,6 +35,34 @@ message CreateChildWorkflowAction {
     optional HistoryPropagationScope historyPropagationScope = 6;
 }
 
+// ScheduleNewWorkflowAction schedules a new, detached workflow instance from a
+// running workflow. Mirrors the fields of CreateInstanceRequest (the client
+// scheduling API) so the runtime has all the information needed to schedule
+// the new instance directly from this action. The spawned workflow is fully
+// decoupled from the caller: no parent pointer is recorded on the new
+// workflow, no completion is awaited, and no failure propagation flows back.
+// The spawn is recorded once in the caller's history as a
+// NewWorkflowScheduledEvent referencing the new instance ID.
+message ScheduleNewWorkflowAction {
+    // instanceId is the ID assigned to the new workflow. It is mandatory:
+    // implementors must set a stable, deterministic ID so that on replay the
+    // call resolves to the same NewWorkflowScheduledEvent in history.
+    string instanceId = 1;
+    // name of the workflow to schedule. Mandatory.
+    string name = 2;
+
+    // The remaining fields mirror the optional inputs of
+    // CreateInstanceRequest. Wrapper types (StringValue) carry presence via
+    // the wrapper; bare message fields are explicitly marked optional.
+    google.protobuf.StringValue version = 3;
+    google.protobuf.StringValue input = 4;
+    optional google.protobuf.Timestamp scheduledStartTimestamp = 5;
+    google.protobuf.StringValue executionId = 6;
+    map<string, string> tags = 7;
+    optional TraceContext parentTraceContext = 8;
+    optional TaskRouter router = 9;
+}
+
 message CreateTimerAction {
     google.protobuf.Timestamp fireAt = 1;
     optional string name = 2;
@@ -82,6 +110,7 @@ message WorkflowAction {
         CompleteWorkflowAction completeWorkflow = 6;
         TerminateWorkflowAction terminateWorkflow = 7;
         WorkflowVersionNotAvailableAction workflowVersionNotAvailable = 10;
+        ScheduleNewWorkflowAction scheduleNewWorkflow = 11;
     }
     reserved 8;
     optional TaskRouter router = 9;


### PR DESCRIPTION
Ref: https://github.com/dapr/dapr/issues/9261

Adds an action for clients to tell the runtime to run a detached workflow from a workflow context, and a history event type so clients can check if it has been properly scheduled, so replays don't send it again.