### PR TITLE
add missing fields to WorkflowState

### DIFF
--- a/protos/orchestration.proto
+++ b/protos/orchestration.proto
@@ -109,4 +109,7 @@ message WorkflowState {
     google.protobuf.Timestamp completedTimestamp = 13;
     google.protobuf.StringValue parentInstanceId = 14;
     map<string, string> tags = 15;
+    google.protobuf.StringValue parentAppId = 16;
+    optional google.protobuf.Timestamp startedAt = 17;
+
 }


### PR DESCRIPTION
The `parentAppID` and `startedAt` fields were added to `WorkflowMetadata` (#42 #49 ) but not to `WorkflowState` and are needed in order to construct the `WorkflowMetadata` in [durabletask-go client](https://github.com/dapr/durabletask-go/blob/main/client/client_grpc.go#L310-L320) from the `WorkflowState`