### PR TITLE
feat: add scheduleIfNotExists option for creating workflow instances

### DIFF
--- a/protos/backend_service.proto
+++ b/protos/backend_service.proto
@@ -96,6 +96,11 @@ message CreateWorkflowInstanceRequest {
 
   // Propagated history from the parent workflow.
   optional PropagatedHistory propagatedHistory = 3;
+
+  // When true, the request fails with an ALREADY_EXISTS error if a workflow
+  // instance with the same instanceId already exists, whether active or
+  // completed. When false, an existing completed instance is restarted.
+  bool enforceUniqueInstanceId = 4;
 }
 
 message WorkflowMetadata {

--- a/protos/orchestrator_service.proto
+++ b/protos/orchestrator_service.proto
@@ -104,6 +104,11 @@ message CreateInstanceRequest {
     google.protobuf.StringValue executionId = 7;
     map<string, string> tags = 8;
     TraceContext parentTraceContext = 9;
+
+    // When true, the request fails with an ALREADY_EXISTS error if a workflow
+    // instance with the same instanceId already exists, whether active or
+    // completed. When false, an existing completed instance is restarted.
+    bool enforceUniqueInstanceId = 10;
 }
 
 message CreateInstanceResponse {


### PR DESCRIPTION
New flag to the CreateWorkflowInstanceRequest to enforce instanceId uniqueness not in case of existing instanceId and not matter the state